### PR TITLE
Disable precompile job by default

### DIFF
--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.5.1
+version: 9.5.2
 
 # renovate: image=ghcr.io/mastodon/mastodon
 appVersion: v4.3.1

--- a/charts/mastodon/README.md
+++ b/charts/mastodon/README.md
@@ -58,7 +58,7 @@ Mastodon is a free, open-source social network server based on ActivityPub.
 | mastodon.deepl.plan | string | `""` |  |
 | mastodon.extraVolumeMounts | list | `[]` | optional extra volume mounts for the mastodon web pod |
 | mastodon.extraVolumes | list | `[]` | optional extra volumes for the mastodon web pod |
-| mastodon.hooks.assetsPrecompile.enabled | bool | `true` |  |
+| mastodon.hooks.assetsPrecompile.enabled | bool | `false` | disabled by default, see [mastodon/chart:#158](https://github.com/mastodon/chart/issues/158#issuecomment-2429186438) |
 | mastodon.hooks.dbMigrate.enabled | bool | `true` |  |
 | mastodon.hooks.s3Upload.acl | string | `"public-read"` |  |
 | mastodon.hooks.s3Upload.bucket | string | `nil` |  |

--- a/charts/mastodon/README.md
+++ b/charts/mastodon/README.md
@@ -1,6 +1,6 @@
 # mastodon
 
-![Version: 9.5.1](https://img.shields.io/badge/Version-9.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.3.1](https://img.shields.io/badge/AppVersion-v4.3.1-informational?style=flat-square)
+![Version: 9.5.2](https://img.shields.io/badge/Version-9.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.3.1](https://img.shields.io/badge/AppVersion-v4.3.1-informational?style=flat-square)
 
 Mastodon is a free, open-source social network server based on ActivityPub.
 

--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -34,7 +34,8 @@ mastodon:
     dbMigrate:
       enabled: true
     assetsPrecompile:
-      enabled: true
+      # -- disabled by default, see [mastodon/chart:#158](https://github.com/mastodon/chart/issues/158#issuecomment-2429186438)
+      enabled: false
     # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are


### PR DESCRIPTION
Looks like the `job-assets-precompile` doesn't need to be run anymore according to https://github.com/mastodon/chart/issues/158#issuecomment-2429186438, but I'll keep it available, just in case someone needs it for a bit. It will be disabled by default now though, as it seems to just break things 😅 