### PR TITLE
apply revision history param to all deployments

### DIFF
--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.6.0
+version: 9.6.1
 
 # renovate: image=ghcr.io/mastodon/mastodon
 appVersion: v4.3.1

--- a/charts/mastodon/README.md
+++ b/charts/mastodon/README.md
@@ -1,6 +1,6 @@
 # mastodon
 
-![Version: 9.6.0](https://img.shields.io/badge/Version-9.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.3.1](https://img.shields.io/badge/AppVersion-v4.3.1-informational?style=flat-square)
+![Version: 9.6.1](https://img.shields.io/badge/Version-9.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.3.1](https://img.shields.io/badge/AppVersion-v4.3.1-informational?style=flat-square)
 
 Mastodon is a free, open-source social network server based on ActivityPub.
 

--- a/charts/mastodon/templates/deployment-sidekiq.yaml
+++ b/charts/mastodon/templates/deployment-sidekiq.yaml
@@ -21,7 +21,7 @@ spec:
   strategy:
     type: Recreate
   {{- end }}
-  revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $context.Values.mastodon.revisionHistoryLimit }}
   replicas: {{ .replicas }}
   selector:
     matchLabels:

--- a/charts/mastodon/templates/deployment-sidekiq.yaml
+++ b/charts/mastodon/templates/deployment-sidekiq.yaml
@@ -21,6 +21,7 @@ spec:
   strategy:
     type: Recreate
   {{- end }}
+  revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   replicas: {{ .replicas }}
   selector:
     matchLabels:

--- a/charts/mastodon/templates/deployment-web.yaml
+++ b/charts/mastodon/templates/deployment-web.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   replicas: {{ .Values.mastodon.web.replicas }}
   selector:
     matchLabels:


### PR DESCRIPTION
`mastodon.revisionHistoryLimit` now applies to all deployments :)